### PR TITLE
Added checks to Anima Dungeon Profiles and Blacklist for Fates.

### DIFF
--- a/Anima Weapons/Dungeons/Amadapor Keep (Hard).xml
+++ b/Anima Weapons/Dungeons/Amadapor Keep (Hard).xml
@@ -12,8 +12,10 @@
 <Profile>
   <Name>Amdapor Keep (Hard)</Name>
   <BehaviorDirectory></BehaviorDirectory>
-  <Order>
-  
+  <Order>	
+	
+  <If Condition="GetQuestStep(67749) == 7">	
+	
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="29"/>
 	</If>
@@ -219,6 +221,11 @@
 		</If>
 		
 	</If>
+	
+  </If>	
+	
+  <LLoadProfile Path="../Start.xml"/>	
+	
   </Order>
   <GrindAreas>
 	<GrindArea name="FirstBoss">

--- a/Anima Weapons/Dungeons/Keeper of the Lake.xml
+++ b/Anima Weapons/Dungeons/Keeper of the Lake.xml
@@ -13,6 +13,9 @@
   <Name>Keeper of the Lake</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>	
+  
+  <If Condition="GetQuestStep(67749) == 5">
+  
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="32"/>
 	</If>
@@ -178,8 +181,9 @@
 
 	</If>
 	
-
-	<LLoadProfile Path="../Start.xml"/>		
+  </If>
+  
+  <LLoadProfile Path="../Start.xml"/>		
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/Sastasha (Hard).xml
+++ b/Anima Weapons/Dungeons/Sastasha (Hard).xml
@@ -13,6 +13,9 @@
   <Name>Sastasha (Hard)</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>
+  
+  <If Condition="GetQuestStep(67749) == 2">
+  
 <!-- [Sastasha (Hard)] It's Definitely Pirates -->
     <If Condition="not HasQuest(65630) and not IsQuestCompleted(65630)">
       <GetTo ZoneId="156" XYZ="32.08445, 21.27369, -636.3706"/>
@@ -203,7 +206,9 @@
 		<TurnIn QuestId="65630" NpcId="1010359" XYZ="206.6833, -24.99666, 242.0538"/>
 	</If>			
 			
-	<LLoadProfile Path="../Start.xml"/>		
+  </If>
+
+  <LLoadProfile Path="../Start.xml"/>		
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/Snowcloak.xml
+++ b/Anima Weapons/Dungeons/Snowcloak.xml
@@ -14,6 +14,9 @@
   <Name>Snowcloak</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>
+  
+  <If Condition="GetQuestStep(67749) == 1">
+  
  	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="27"/>>
 	</If>
@@ -171,7 +174,9 @@
 		</If>
 	</If>
 
-	<LLoadProfile Path="../Start.xml"/>
+  </If>
+
+  <LLoadProfile Path="../Start.xml"/>
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/Sohm Al.xml
+++ b/Anima Weapons/Dungeons/Sohm Al.xml
@@ -14,6 +14,9 @@
   <Name>Sohm Al</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>
+  
+  <If Condition="GetQuestStep(67749) == 10">
+  
  	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="37"/>
 	</If>
@@ -177,8 +180,9 @@
 		</If>
 	</If>
 
-	<LLoadProfile Path="../Start.xml"/>	
-
+  </If>
+  
+  <LLoadProfile Path="../Start.xml"/>	
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/The Aery.xml
+++ b/Anima Weapons/Dungeons/The Aery.xml
@@ -13,6 +13,9 @@
   <Name>The Aery</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>	
+  
+  <If Condition="GetQuestStep(67749) == 11">
+  
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="39"/>
 	</If>
@@ -198,8 +201,9 @@
 		
 	</If>
 	
-
-	<LLoadProfile Path="../Start.xml"/>		
+  </If>	
+	
+  <LLoadProfile Path="../Start.xml"/>	  
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/The Dusk Vigil.xml
+++ b/Anima Weapons/Dungeons/The Dusk Vigil.xml
@@ -13,6 +13,9 @@
   <Name>The Dusk Vigil</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>	
+  
+  <If Condition="GetQuestStep(67749) == 9">
+  
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="36"/>
 	</If>
@@ -203,8 +206,9 @@
 
 	</If>
 	
-
-	<LLoadProfile Path="../Start.xml"/>		
+  </If>
+  
+  <LLoadProfile Path="../Start.xml"/>	
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/The Sunken Temple of Qarn (Hard).xml
+++ b/Anima Weapons/Dungeons/The Sunken Temple of Qarn (Hard).xml
@@ -13,6 +13,9 @@
   <Name>The Sunken Temple of Qarn</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>
+  
+  <If Condition="GetQuestStep(67749) == 3">
+  
     <!-- [The Sunken Temple of Qarn (Hard)] The Wrath of Qarn -->
     <If Condition="not HasQuest(65632) and not IsQuestCompleted(65632)">
       <GetTo ZoneId="156" XYZ="26.70581, 21.25273, -637.3229"/>
@@ -241,8 +244,10 @@
 		<GetTo ZoneId="131" XYZ="-9.669962, 7.5, 147.9098"/>
 		<TurnIn QuestId="65632" NpcId="1010365" XYZ="-10.63556, 7.499994, 146.6849"/>
 	</If>
-
-	<LLoadProfile Path="../Start.xml"/>		
+	
+  </If>
+  
+  <LLoadProfile Path="../Start.xml"/>		
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/The Vault.xml
+++ b/Anima Weapons/Dungeons/The Vault.xml
@@ -13,6 +13,9 @@
   <Name>The Vault</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>	
+  
+  <If Condition="GetQuestStep(67749) == 12">
+  
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="34"/>
 	</If>
@@ -178,8 +181,9 @@
 		</If>	
 	</If>
 	
-
-	<LLoadProfile Path="../Start.xml"/>		
+  </If>
+  
+  <LLoadProfile Path="../Start.xml"/>		
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Dungeons/The Wanderer's Palace (Hard).xml
+++ b/Anima Weapons/Dungeons/The Wanderer's Palace (Hard).xml
@@ -13,6 +13,9 @@
   <Name>The Wanderer's Palace (Hard)</Name>
   <BehaviorDirectory></BehaviorDirectory>
   <Order>	
+  
+  <If Condition="GetQuestStep(67749) == 6">
+  
 	<If condition="not DutyManager.InInstance">
 		<LLJoinDuty DutyId="30"/>
 	</If>
@@ -192,8 +195,9 @@
 
 	</If>
 	
+  </If>
 
-	<LLoadProfile Path="../Start.xml"/>		
+  <LLoadProfile Path="../Start.xml"/>		
 	
   </Order>
   <GrindAreas>

--- a/Anima Weapons/Quests/Luminous Crystal Farm.xml
+++ b/Anima Weapons/Quests/Luminous Crystal Farm.xml
@@ -18,7 +18,7 @@
 		  </If>
           <While Condition="not HasAtLeast(13569,1)">
 			<Log Message="Farming Luminous Ice Crystal in Coerthas Western Highlands..." />
-            <LLFate MinLevel="1" MaxLevel="80" while="not HasAtLeast(13569,1)"/>
+            <LLFate MinLevel="1" MaxLevel="80" BlacklistID="793" while="not HasAtLeast(13569,1)"/>
           </While>		  
 		 </If>
 
@@ -51,7 +51,7 @@
 		  </If>				             
           <While Condition="not HasAtLeast(13572,1)">
 			<Log Message="Farming Luminous Earth Crystal in The Dravanian Forelands..." />
-            <LLFate MinLevel="1" MaxLevel="80" while="not HasAtLeast(13572,1)"/>
+            <LLFate MinLevel="1" MaxLevel="80" BlacklistID="838" while="not HasAtLeast(13572,1)"/>
           </While>
         </While>
 		


### PR DESCRIPTION
Added checks so that if you start the profile and are on a different step it should reload start profile instead of doing the dungeon again.

**Added Blacklist for Fates for Crystal farming:**
"We Fought a Dzu" - Coerthas Western Highlands 
"Special Tarasque Forc" - The Dravanian Forelands