### PR TITLE
Try to fix A1 stuck problem

### DIFF
--- a/Anima Weapons/Dungeons/Alexander A1 - The Fist of the Father.xml
+++ b/Anima Weapons/Dungeons/Alexander A1 - The Fist of the Father.xml
@@ -25,6 +25,7 @@
 			<If Condition="GetInstanceTodo(0) == 0">
 				<Log Message="Clear Engine Room #262 0/1" />
 				<BotSettings AutoEquip="1" />
+				<MoveTo XYZ="-0.2103347, -5.143304, 8.119263" />
 				<MoveTo XYZ="-5.779995, -1.301059, -6.571419" />
 				<MoveTo XYZ="0.02018939, 8.000002, -43.64269" />
 			</If>


### PR DESCRIPTION
Added a hotspot in the middle to avoid stuck in engine room #262 due to random pattern of map layout
There are like 3~4 patterns and two of them can stuck you with default nav.
Each has a dead end on one side of the engine room.
see: https://imgur.com/a/ZIerI8e