### PR TITLE
Split 23-25 grind area, add multi-language support and timeout handling

### DIFF
--- a/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
+++ b/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
@@ -33,8 +33,12 @@
 			<Grind GrindRef="21to22" while="Core.Me.ElementalLevel &lt; 23"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 25">
+			<NoCombatMoveTo XYZ="-215.3304, -726.7948, 398.8835" />
+			<Grind GrindRef="23to24" while="Core.Me.ElementalLevel &lt; 25"/>		
+		</While>
+		<While Condition="Core.Me.ElementalLevel &lt; 26">
 			<NoCombatMoveTo XYZ="53.07406, -737.6741, 324.4169" />
-			<Grind GrindRef="23to25" while="Core.Me.ElementalLevel &lt; 25"/>		
+			<Grind GrindRef="Level25" while="Core.Me.ElementalLevel &lt; 26"/>		
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 27">
 			<NoCombatMoveTo XYZ="447.303, -740.0225, 435.4175" />
@@ -127,32 +131,42 @@
         <TargetMob Id="7415" Weight="1"/> <!-- Val Roselet -->
       </TargetMobs>
     </GrindArea>
-		<GrindArea name="23to25">
-					<Hotspots>
-				<Hotspot Radius="200" XYZ="53.07406, -737.6741, 324.4169" />
-					</Hotspots>
-					<TargetMobs>
-				<TargetMob Id="7413" Weight="1" /> <!-- Yukinko -->
-					</TargetMobs>
-		</GrindArea>		
-		<GrindArea name="25to27">
-					<Hotspots>
-				<Hotspot Radius="200" XYZ="448.0505,-736.2757,391.8059" />
-				<Hotspot Radius="200" XYZ="371.8877,-737.534,446.8703" />
-					</Hotspots>
-					<TargetMobs>
-				<TargetMob Id="7434" Weight="1" /> <!-- Blood Demon -->
-					</TargetMobs>
-		</GrindArea>	
-		<GrindArea name="27to28">
-					<Hotspots>
-				<Hotspot Radius="200" XYZ="567.0404,-723.0895,247.6082" />
-				<Hotspot Radius="200" XYZ="548.2413,-726.4501,329.7932" />
-					</Hotspots>
-					<TargetMobs>
-				<TargetMob Id="7453" Weight="1" /> <!-- Val Worm -->
-					</TargetMobs>
-		</GrindArea>
+	<GrindArea name="23to24">
+		<Hotspots>
+			<Hotspot Radius="200" XYZ="-215.3304, -726.7948, 398.8835" />
+		</Hotspots>
+		<TargetMobs>
+			<TargetMob Id="7407" Weight="1" /> <!-- 雪地海月水母 -->
+			<TargetMob Id="7469" Weight="1" /> <!-- 雪暴元精 -->
+			<TargetMob Id="7464" Weight="1" /> <!-- Zombie Brobinyak -->
+		</TargetMobs>
+	</GrindArea>
+	<GrindArea name="Level25">
+		<Hotspots>
+			<Hotspot Radius="200" XYZ="53.07406, -737.6741, 324.4169" />
+		</Hotspots>
+		<TargetMobs>
+			<TargetMob Id="7413" Weight="1" /> <!-- Yukinko -->
+		</TargetMobs>
+	</GrindArea>		
+	<GrindArea name="25to27">
+		<Hotspots>
+			<Hotspot Radius="200" XYZ="448.0505,-736.2757,391.8059" />
+			<Hotspot Radius="200" XYZ="371.8877,-737.534,446.8703" />
+		</Hotspots>
+		<TargetMobs>
+			<TargetMob Id="7434" Weight="1" /> <!-- Blood Demon -->
+		</TargetMobs>
+	</GrindArea>	
+	<GrindArea name="27to28">
+		<Hotspots>
+			<Hotspot Radius="200" XYZ="567.0404,-723.0895,247.6082" />
+			<Hotspot Radius="200" XYZ="548.2413,-726.4501,329.7932" />
+		</Hotspots>
+		<TargetMobs>
+			<TargetMob Id="7453" Weight="1" /> <!-- Val Worm -->
+		</TargetMobs>
+	</GrindArea>
  	<GrindArea name="28to31">
         <Hotspots>
 			<Hotspot Radius="200" XYZ="359.3042,-680.7711,13.50421" />
@@ -218,7 +232,37 @@
 					await Buddy.Coroutines.Coroutine.Sleep(500);
 					{
 						Logging.WriteDiagnostic("Choosing Eureka Pagos.");
-						SelectString.ClickLineContains("Pagos");;
+						Logging.WriteDiagnostic("Choosing Eureka Pagos.");
+    
+						// 優先嘗試英文 "Pagos"
+						if (SelectString.ClickLineContains("Pagos"))
+						{
+							Logging.WriteDiagnostic("Selected using 'Pagos'.");
+						}
+						// 如果找不到，嘗試繁體中文 "禁地優雷卡 恆冰之地"
+						else if (SelectString.ClickLineContains("禁地優雷卡 恆冰之地"))
+						{
+							Logging.WriteDiagnostic("Selected using '禁地優雷卡 恆冰之地'.");
+						}
+						// 如果還是找不到，嘗試簡體中文 "禁地优雷卡 恒冰之地"
+						else if (SelectString.ClickLineContains("禁地优雷卡 恒冰之地"))
+						{
+							Logging.WriteDiagnostic("Selected using '禁地优雷卡 恒冰之地'.");
+						}
+						// 如果都找不到，嘗試只匹配 "恆冰之地" 或 "恒冰之地"
+						else if (SelectString.ClickLineContains("恆冰之地"))
+						{
+							Logging.WriteDiagnostic("Selected using '恆冰之地'.");
+						}
+						else if (SelectString.ClickLineContains("恒冰之地"))
+						{
+							Logging.WriteDiagnostic("Selected using '恒冰之地'.");
+						}
+						else
+						{
+							Logging.WriteDiagnostic("Could not find any matching text, trying first option.");
+							SelectString.ClickSlot(0);
+						}
 					}					
 							
 					await Coroutine.Wait(5000, () => SelectYesno.IsOpen);

--- a/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
+++ b/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Profile: Eureka Pagos Leveling
-  Authors: DomesticWarlord86
+  Authors: DomesticWarlord86, 0xAlbertLin
 -->
 
 <!DOCTYPE Profile [
@@ -20,84 +20,86 @@
 		<RunCode name="EnterPagos"/>
 	</While>
  	<While Condition="IsOnMap(763)">
+		<!-- Exit loop immediately if not in Eureka Pagos (e.g., timeout) -->
+		
 		<While Condition="Core.Me.ElementalLevel &lt; 20">
 			<NoCombatMoveTo XYZ="-578.9044, -700.8606, 86.51808" />
-			<Grind GrindRef="Under20" while="Core.Me.ElementalLevel &lt; 20"/>
+			<Grind GrindRef="Under20" while="Core.Me.ElementalLevel &lt; 20 and IsOnMap(763)"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 22">
 			<MoveTo XYZ="-472.8371, -704.0522, 252.6677" />
-			<Grind GrindRef="20to21" while="Core.Me.ElementalLevel &lt; 22"/>
+			<Grind GrindRef="20to21" while="Core.Me.ElementalLevel &lt; 22 and IsOnMap(763)"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 23">
 			<MoveTo XYZ="-324.5545, -674.0774, 167.9012" />
-			<Grind GrindRef="21to22" while="Core.Me.ElementalLevel &lt; 23"/>
+			<Grind GrindRef="21to22" while="Core.Me.ElementalLevel &lt; 23 and IsOnMap(763)"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 25">
 			<NoCombatMoveTo XYZ="-215.3304, -726.7948, 398.8835" />
-			<Grind GrindRef="23to24" while="Core.Me.ElementalLevel &lt; 25"/>		
+			<Grind GrindRef="23to24" while="Core.Me.ElementalLevel &lt; 25 and IsOnMap(763)"/>		
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 26">
 			<NoCombatMoveTo XYZ="53.07406, -737.6741, 324.4169" />
-			<Grind GrindRef="Level25" while="Core.Me.ElementalLevel &lt; 26"/>		
+			<Grind GrindRef="Level25" while="Core.Me.ElementalLevel &lt; 26 and IsOnMap(763)"/>		
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 27">
 			<NoCombatMoveTo XYZ="447.303, -740.0225, 435.4175" />
 			<If Condition="&DoFates; == 1">
-				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and not IsFateActive(1353)"/>
+				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and not IsFateActive(1353) and IsOnMap(763)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1353" MinLevel="1" MaxLevel="80" while="IsFateActive(1353)"/>
+				<LLFate FateId="1353" MinLevel="1" MaxLevel="80" while="IsFateActive(1353) and IsOnMap(763)"/>
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27"/>
+				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and IsOnMap(763)"/>
 			</If>				
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 28">
 			<NoCombatMoveTo XYZ="586.6545, -728.2477, 294.0709" />
 			<If Condition="&DoFates; == 1">
-				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and not IsFateActive(1354)"/>
+				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and not IsFateActive(1354) and IsOnMap(763)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1354" MinLevel="1" MaxLevel="80" while="IsFateActive(1354)"/>	
+				<LLFate FateId="1354" MinLevel="1" MaxLevel="80" while="IsFateActive(1354) and IsOnMap(763)"/>	
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28"/>
+				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and IsOnMap(763)"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 30">
 			<NoCombatMoveTo XYZ="374.9399, -681.7018, 21.94587" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="28to31" while="not IsFateActive(1366) and Core.Me.ElementalLevel &lt; 30"/>
+				<Grind GrindRef="28to31" while="not IsFateActive(1366) and Core.Me.ElementalLevel &lt; 30 and IsOnMap(763)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1366" MinLevel="1" MaxLevel="80" while="IsFateActive(1366)"/>					
+				<LLFate FateId="1366" MinLevel="1" MaxLevel="80" while="IsFateActive(1366) and IsOnMap(763)"/>					
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="28to31" while="Core.Me.ElementalLevel &lt; 30"/>
+				<Grind GrindRef="28to31" while="Core.Me.ElementalLevel &lt; 30 and IsOnMap(763)"/>
 			</If>			
 		</While>	
 		<While condition="Core.Me.ElementalLevel &lt; 31">
 			<NoCombatMoveTo XYZ="-572.523, -607.4022, -527.281" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="31to32" while="not IsFateActive(1356) and Core.Me.ElementalLevel &lt; 31"/>
+				<Grind GrindRef="31to32" while="not IsFateActive(1356) and Core.Me.ElementalLevel &lt; 31 and IsOnMap(763)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1356" MinLevel="1" MaxLevel="80" while="IsFateActive(1356)"/>							
+				<LLFate FateId="1356" MinLevel="1" MaxLevel="80" while="IsFateActive(1356) and IsOnMap(763)"/>							
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="31to32" while="Core.Me.ElementalLevel &lt; 31"/>
+				<Grind GrindRef="31to32" while="Core.Me.ElementalLevel &lt; 31 and IsOnMap(763)"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 33">
 			<NoCombatMoveTo XYZ="-583.2302, -615.7835, -110.5662" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="32to35" while="not IsFateActive(1352) and Core.Me.ElementalLevel &lt; 33"/>
+				<Grind GrindRef="32to35" while="not IsFateActive(1352) and Core.Me.ElementalLevel &lt; 33 and IsOnMap(763)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1352" MinLevel="1" MaxLevel="80" while="IsFateActive(1352)"/>						
+				<LLFate FateId="1352" MinLevel="1" MaxLevel="80" while="IsFateActive(1352) and IsOnMap(763)"/>						
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="32to35" while="Core.Me.ElementalLevel &lt; 33"/>
+				<Grind GrindRef="32to35" while="Core.Me.ElementalLevel &lt; 33 and IsOnMap(763)"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 36">
 			<NoCombatMoveTo XYZ="-668.0698, -619.3779, -158.808" />
-			<Grind GrindRef="33to35" while="Core.Me.ElementalLevel &lt; 36"/>		
+			<Grind GrindRef="33to35" while="Core.Me.ElementalLevel &lt; 36 and IsOnMap(763)"/>		
 		</While>		
 	</While>
 	
@@ -231,7 +233,6 @@
 					await Coroutine.Wait(10000, () => SelectString.IsOpen);
 					await Buddy.Coroutines.Coroutine.Sleep(500);
 					{
-						Logging.WriteDiagnostic("Choosing Eureka Pagos.");
 						Logging.WriteDiagnostic("Choosing Eureka Pagos.");
     
 						// 優先嘗試英文 "Pagos"

--- a/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
+++ b/Relic Weapons/Eureka/Eureka Pagos Leveling.xml
@@ -20,86 +20,84 @@
 		<RunCode name="EnterPagos"/>
 	</While>
  	<While Condition="IsOnMap(763)">
-		<!-- Exit loop immediately if not in Eureka Pagos (e.g., timeout) -->
-		
 		<While Condition="Core.Me.ElementalLevel &lt; 20">
 			<NoCombatMoveTo XYZ="-578.9044, -700.8606, 86.51808" />
-			<Grind GrindRef="Under20" while="Core.Me.ElementalLevel &lt; 20 and IsOnMap(763)"/>
+			<Grind GrindRef="Under20" while="Core.Me.ElementalLevel &lt; 20"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 22">
 			<MoveTo XYZ="-472.8371, -704.0522, 252.6677" />
-			<Grind GrindRef="20to21" while="Core.Me.ElementalLevel &lt; 22 and IsOnMap(763)"/>
+			<Grind GrindRef="20to21" while="Core.Me.ElementalLevel &lt; 22"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 23">
 			<MoveTo XYZ="-324.5545, -674.0774, 167.9012" />
-			<Grind GrindRef="21to22" while="Core.Me.ElementalLevel &lt; 23 and IsOnMap(763)"/>
+			<Grind GrindRef="21to22" while="Core.Me.ElementalLevel &lt; 23"/>
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 25">
 			<NoCombatMoveTo XYZ="-215.3304, -726.7948, 398.8835" />
-			<Grind GrindRef="23to24" while="Core.Me.ElementalLevel &lt; 25 and IsOnMap(763)"/>		
+			<Grind GrindRef="23to24" while="Core.Me.ElementalLevel &lt; 25"/>		
 		</While>
 		<While Condition="Core.Me.ElementalLevel &lt; 26">
 			<NoCombatMoveTo XYZ="53.07406, -737.6741, 324.4169" />
-			<Grind GrindRef="Level25" while="Core.Me.ElementalLevel &lt; 26 and IsOnMap(763)"/>		
+			<Grind GrindRef="Level25" while="Core.Me.ElementalLevel &lt; 26"/>		
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 27">
 			<NoCombatMoveTo XYZ="447.303, -740.0225, 435.4175" />
 			<If Condition="&DoFates; == 1">
-				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and not IsFateActive(1353) and IsOnMap(763)"/>
+				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and not IsFateActive(1353)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1353" MinLevel="1" MaxLevel="80" while="IsFateActive(1353) and IsOnMap(763)"/>
+				<LLFate FateId="1353" MinLevel="1" MaxLevel="80" while="IsFateActive(1353)"/>
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27 and IsOnMap(763)"/>
+				<Grind GrindRef="25to27" while="Core.Me.ElementalLevel &lt; 27"/>
 			</If>				
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 28">
 			<NoCombatMoveTo XYZ="586.6545, -728.2477, 294.0709" />
 			<If Condition="&DoFates; == 1">
-				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and not IsFateActive(1354) and IsOnMap(763)"/>
+				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and not IsFateActive(1354)"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1354" MinLevel="1" MaxLevel="80" while="IsFateActive(1354) and IsOnMap(763)"/>	
+				<LLFate FateId="1354" MinLevel="1" MaxLevel="80" while="IsFateActive(1354)"/>	
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28 and IsOnMap(763)"/>
+				<Grind GrindRef="27to28" while="Core.Me.ElementalLevel &lt; 28"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 30">
 			<NoCombatMoveTo XYZ="374.9399, -681.7018, 21.94587" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="28to31" while="not IsFateActive(1366) and Core.Me.ElementalLevel &lt; 30 and IsOnMap(763)"/>
+				<Grind GrindRef="28to31" while="not IsFateActive(1366) and Core.Me.ElementalLevel &lt; 30"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1366" MinLevel="1" MaxLevel="80" while="IsFateActive(1366) and IsOnMap(763)"/>					
+				<LLFate FateId="1366" MinLevel="1" MaxLevel="80" while="IsFateActive(1366)"/>					
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="28to31" while="Core.Me.ElementalLevel &lt; 30 and IsOnMap(763)"/>
+				<Grind GrindRef="28to31" while="Core.Me.ElementalLevel &lt; 30"/>
 			</If>			
 		</While>	
 		<While condition="Core.Me.ElementalLevel &lt; 31">
 			<NoCombatMoveTo XYZ="-572.523, -607.4022, -527.281" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="31to32" while="not IsFateActive(1356) and Core.Me.ElementalLevel &lt; 31 and IsOnMap(763)"/>
+				<Grind GrindRef="31to32" while="not IsFateActive(1356) and Core.Me.ElementalLevel &lt; 31"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1356" MinLevel="1" MaxLevel="80" while="IsFateActive(1356) and IsOnMap(763)"/>							
+				<LLFate FateId="1356" MinLevel="1" MaxLevel="80" while="IsFateActive(1356)"/>							
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="31to32" while="Core.Me.ElementalLevel &lt; 31 and IsOnMap(763)"/>
+				<Grind GrindRef="31to32" while="Core.Me.ElementalLevel &lt; 31"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 33">
 			<NoCombatMoveTo XYZ="-583.2302, -615.7835, -110.5662" />
 			<If Condition="&DoFates; == 1">				
-				<Grind GrindRef="32to35" while="not IsFateActive(1352) and Core.Me.ElementalLevel &lt; 33 and IsOnMap(763)"/>
+				<Grind GrindRef="32to35" while="not IsFateActive(1352) and Core.Me.ElementalLevel &lt; 33"/>
 				<RunCode name="LevelSync"/>
-				<LLFate FateId="1352" MinLevel="1" MaxLevel="80" while="IsFateActive(1352) and IsOnMap(763)"/>						
+				<LLFate FateId="1352" MinLevel="1" MaxLevel="80" while="IsFateActive(1352)"/>						
 			</If>
 			<If Condition="&DoFates; == 0">
-				<Grind GrindRef="32to35" while="Core.Me.ElementalLevel &lt; 33 and IsOnMap(763)"/>
+				<Grind GrindRef="32to35" while="Core.Me.ElementalLevel &lt; 33"/>
 			</If>			
 		</While>
 		<While condition="Core.Me.ElementalLevel &lt; 36">
 			<NoCombatMoveTo XYZ="-668.0698, -619.3779, -158.808" />
-			<Grind GrindRef="33to35" while="Core.Me.ElementalLevel &lt; 36 and IsOnMap(763)"/>		
+			<Grind GrindRef="33to35" while="Core.Me.ElementalLevel &lt; 36"/>		
 		</While>		
 	</While>
 	
@@ -215,84 +213,82 @@
 			<![CDATA[
 				var npcId = GameObjectManager.GetObjectByNPCId(1024517);
 
-					if (!npcId.IsWithinInteractRange)
-
-						{
-							var _target = npcId.Location;
-							Navigator.PlayerMover.MoveTowards(_target);
-							while (_target.Distance2D(Core.Me.Location) >= 4)
-								{
-									Navigator.PlayerMover.MoveTowards(_target);
-									await Coroutine.Sleep(100);
-								}
-									Navigator.PlayerMover.MoveStop();
-								}
-
-					npcId.Interact();
-
-					await Coroutine.Wait(10000, () => SelectString.IsOpen);
-					await Buddy.Coroutines.Coroutine.Sleep(500);
+				if (!npcId.IsWithinInteractRange)
+				{
+					var _target = npcId.Location;
+					Navigator.PlayerMover.MoveTowards(_target);
+					while (_target.Distance2D(Core.Me.Location) >= 4)
 					{
-						Logging.WriteDiagnostic("Choosing Eureka Pagos.");
-    
-						// 優先嘗試英文 "Pagos"
-						if (SelectString.ClickLineContains("Pagos"))
-						{
-							Logging.WriteDiagnostic("Selected using 'Pagos'.");
-						}
-						// 如果找不到，嘗試繁體中文 "禁地優雷卡 恆冰之地"
-						else if (SelectString.ClickLineContains("禁地優雷卡 恆冰之地"))
-						{
-							Logging.WriteDiagnostic("Selected using '禁地優雷卡 恆冰之地'.");
-						}
-						// 如果還是找不到，嘗試簡體中文 "禁地优雷卡 恒冰之地"
-						else if (SelectString.ClickLineContains("禁地优雷卡 恒冰之地"))
-						{
-							Logging.WriteDiagnostic("Selected using '禁地优雷卡 恒冰之地'.");
-						}
-						// 如果都找不到，嘗試只匹配 "恆冰之地" 或 "恒冰之地"
-						else if (SelectString.ClickLineContains("恆冰之地"))
-						{
-							Logging.WriteDiagnostic("Selected using '恆冰之地'.");
-						}
-						else if (SelectString.ClickLineContains("恒冰之地"))
-						{
-							Logging.WriteDiagnostic("Selected using '恒冰之地'.");
-						}
-						else
-						{
-							Logging.WriteDiagnostic("Could not find any matching text, trying first option.");
-							SelectString.ClickSlot(0);
-						}
-					}					
-							
-					await Coroutine.Wait(5000, () => SelectYesno.IsOpen);
-					await Buddy.Coroutines.Coroutine.Sleep(500);
-					if (ff14bot.RemoteWindows.SelectYesno.IsOpen)
-						{
-							Logging.WriteDiagnostic("Selecting Yes.");
-							ff14bot.RemoteWindows.SelectYesno.ClickYes();	
-						}
+						Navigator.PlayerMover.MoveTowards(_target);
+						await Coroutine.Sleep(100);
+					}
+					Navigator.PlayerMover.MoveStop();
+				}
 
-					await Coroutine.Wait(5000, () => ContentsFinderConfirm.IsOpen);
-					await Buddy.Coroutines.Coroutine.Sleep(500);
-				   
-					if (ff14bot.RemoteWindows.ContentsFinderConfirm.IsOpen)						
-						{
-							Logging.WriteDiagnostic("Commencing Duty.");
-							ff14bot.RemoteWindows.ContentsFinderConfirm.Commence();
-							await Coroutine.Wait(10000, () => CommonBehaviors.IsLoading);
-							   if (CommonBehaviors.IsLoading)
-							   {
-								   await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
-							   }									
-						}			
+				npcId.Interact();
+
+				await Coroutine.Wait(10000, () => SelectString.IsOpen);
+				await Buddy.Coroutines.Coroutine.Sleep(500);
+				
+				if (SelectString.IsOpen)
+				{
+					Logging.WriteDiagnostic("Choosing Eureka Pagos.");
+					
+					// Try English first
+					if (SelectString.ClickLineContains("Pagos"))
+					{
+						Logging.WriteDiagnostic("Selected using 'Pagos'.");
+					}
+					// Try Traditional Chinese
+					else if (SelectString.ClickLineContains("禁地優雷卡 恆冰之地"))
+					{
+						Logging.WriteDiagnostic("Selected using '禁地優雷卡 恆冰之地'.");
+					}
+					// Try Simplified Chinese
+					else if (SelectString.ClickLineContains("禁地优雷卡 恒冰之地"))
+					{
+						Logging.WriteDiagnostic("Selected using '禁地优雷卡 恒冰之地'.");
+					}
+					// Try partial match for Traditional Chinese
+					else if (SelectString.ClickLineContains("恆冰之地"))
+					{
+						Logging.WriteDiagnostic("Selected using '恆冰之地'.");
+					}
+					// Try partial match for Simplified Chinese
+					else if (SelectString.ClickLineContains("恒冰之地"))
+					{
+						Logging.WriteDiagnostic("Selected using '恒冰之地'.");
+					}
+					// Fallback to first option
+					else
+					{
+						Logging.WriteDiagnostic("Could not find matching text, trying first option.");
+						SelectString.ClickSlot(0);
+					}
+				}					
+						
+				await Coroutine.Wait(5000, () => SelectYesno.IsOpen);
+				await Buddy.Coroutines.Coroutine.Sleep(500);
+				if (ff14bot.RemoteWindows.SelectYesno.IsOpen)
+				{
+					Logging.WriteDiagnostic("Selecting Yes.");
+					ff14bot.RemoteWindows.SelectYesno.ClickYes();	
+				}
+
+				await Coroutine.Wait(5000, () => ContentsFinderConfirm.IsOpen);
+				await Buddy.Coroutines.Coroutine.Sleep(500);
+			   
+				if (ff14bot.RemoteWindows.ContentsFinderConfirm.IsOpen)						
+				{
+					Logging.WriteDiagnostic("Commencing Duty.");
+					ff14bot.RemoteWindows.ContentsFinderConfirm.Commence();
+					await Coroutine.Wait(10000, () => CommonBehaviors.IsLoading);
+					if (CommonBehaviors.IsLoading)
+					{
+						await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
+					}									
+				}			
 			]]>			
 		</CodeChunk>		
-		<CodeChunk Name="LevelSync">
-			<![CDATA[
-				ff14bot.RemoteWindows.ToDoList.LevelSync();
-			]]>			
-		</CodeChunk>
 	</CodeChunks>  
 </Profile>  


### PR DESCRIPTION
- Split 23-25 grind area into separate 23to24 and Level25 areas / Because when I was level 23, I was easily ganged up on and killed by level 25 monsters.
- Add multi-language support for  Eureka Pagos of selection (EN/CN)
- Fix GrindArea name mismatches in profile